### PR TITLE
Add stecman/symfony-console-completion to the suggested package list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
     "phpunit/phpunit": "4.3.5",
     "mikey179/vfsStream": "1.4.0"
   },
+  "suggest": {
+    "stecman/symfony-console-completion": "Enables bash tab completion of Flo commands"
+  },
   "autoload": {
     "psr-0": { "flo": "src/" }
   },


### PR DESCRIPTION
stecman/symfony-console-completion adds tab completion for Flo (and any other Symfony console app (including Composer) if you install it globally). Makes the experience a lot nicer!