### PR TITLE
Fix the way Flo adds/removes github lables.

### DIFF
--- a/src/flo/Command/Command.php
+++ b/src/flo/Command/Command.php
@@ -92,7 +92,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
     }
 
     $github = $this->getGithub(FALSE, 'issue');
-    $github->labels()->add(
+    $github->api('issue')->labels()->add(
       $this->getConfigParameter('organization'),
       $this->getConfigParameter('repository'),
       $pr_number,
@@ -118,7 +118,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
       throw new \Exception("PR must be a number.");
     }
     $github = $this->getGithub(FALSE, 'issue');
-    $github->labels()->remove(
+    $github->api('issue')->labels()->remove(
       $this->getConfigParameter('organization'),
       $this->getConfigParameter('repository'),
       $pr_number,


### PR DESCRIPTION
I dont see how this ever worked, but according to the Docs, the "api" method needs to be called before adding labels. What am I missing here? For reference, this came out of issue that the Pub7 team had when updating to the latest version Flo. The Deploy Integration job resulted in something like this (after an unresolvable code conflict): 

```bash
Automatic merge failed; fix conflicts and then commit the result.

                                             
  [Github\Exception\BadMethodCallException]  
  Undefined method called: "labels"          
                                             
```

see
https://github.com/KnpLabs/php-github-api/blob/master/doc/issue/labels.md