### PR TITLE
Account for multiple GitHub calls in one command

### DIFF
--- a/src/flo/Command/Command.php
+++ b/src/flo/Command/Command.php
@@ -43,8 +43,8 @@ class Command extends \Symfony\Component\Console\Command\Command {
   /**
    * @return Github\Client
    */
-  public function getGithub($cache = TRUE, $api = NULL) {
-    if (null === $this->github) {
+  public function getGithub($cache = TRUE, $api = NULL, $reset = TRUE) {
+    if ($this->github === NULL || $reset === TRUE) {
       if ($cache) {
         $this->github = new Github\Client(
           new Github\HttpClient\CachedHttpClient(array('cache_dir' => '/tmp/github-api-cache'))


### PR DESCRIPTION
cc @bleen @robcolburn @msound 

This is the reason https://github.com/NBCUOTS/flo/pull/173 was failing.

The PR integration calls ```$this->getGithub``` with the cache parameter on to get the list of the PRs, then it calls it again but by then we already have a cache object so it just returns it.

This PR adds a reset so any calls can always decided to get a clean non cache object for when it needs to do writes.