### PR TITLE
Output regardless of status.

### DIFF
--- a/src/flo/Command/PullRequest/DeployCommand.php
+++ b/src/flo/Command/PullRequest/DeployCommand.php
@@ -231,6 +231,7 @@ class DeployCommand extends Command {
       );
     }
 
+    $output->writeln($process->getOutput());
     $output->writeln("<info>PR #$pr_number has been deployed to {$url}.</info>");
   }
 }


### PR DESCRIPTION
Previously we would only get output if the process failed and an
exception was thrown with the errorOutput.