### PR TITLE
Composer, set secure-http to false

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,5 +64,8 @@
   "bin": ["bin/flo"],
   "scripts": {
     "test": "phpunit"
+  },
+  "config": {
+    "secure-http": false
   }
 }


### PR DESCRIPTION
Had to do this for `drupal/coder` since it's `http`. Is there a better way to handle this?

cc @mauricio-molina @ericduran 